### PR TITLE
Change websockets to aiohttp to make it compatible to python3.7

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 import asyncio
 import logging
-import websockets
+import aiohttp
 
 import sc2
 from sc2 import Race, Difficulty
@@ -67,7 +67,7 @@ def run_ladder_game(bot):
 # Modified version of sc2.main._join_game to allow custom host and port, and to not spawn an additional sc2process (thanks to alkurbatov for fix)
 async def join_ladder_game(host, port, players, realtime, portconfig, save_replay_as=None, step_time_limit=None, game_time_limit=None):
     ws_url = "ws://{}:{}/sc2api".format(host, port)
-    ws_connection = await websockets.connect(ws_url, timeout=120)
+    ws_connection = await aiohttp.ClientSession().ws_connect(ws_url, timeout=120)
     client = Client(ws_connection)
 
     try:


### PR DESCRIPTION
Since the new python-sc2 library uses aiohttp instead of websockets and the new pip version got released, the ladder server updated aswell and so all python-sc2 bots require this fix.