### PR TITLE
Add required ladderbots json file

### DIFF
--- a/ladderbots.json
+++ b/ladderbots.json
@@ -1,0 +1,10 @@
+{
+  "Bots": {
+    "example_bot": {
+      "Race": "Protoss",
+      "Type": "Python",
+      "RootPath": "./",
+      "FileName": "run.py"
+    }
+  }
+}


### PR DESCRIPTION
For the new ladder manager, each bot needs to be supplied with a ladderbots.json file, see <http://wiki.sc2ai.net/Bot_Upload_Checklist>

The bot name should be the same name as the `.zip` file name, here it should be zipped as `example_bot.zip`
The `Race` is one of `Protoss`, `Terran`, `Zerg` and `Random`
The `Type` can be `Python` if the executeable filename is a python file, or `BinaryCpp` if it is an `.exe` file